### PR TITLE
Rename artboard and move selected layers

### DIFF
--- a/SizeArtboard.sketchplugin/Contents/Sketch/script.cocoascript
+++ b/SizeArtboard.sketchplugin/Contents/Sketch/script.cocoascript
@@ -1,34 +1,34 @@
 var onRun = function(context) {
   var doc = context.document
 
-//get selection
-var selection = context.selection
-var handler = context.document.eventHandlerManager().normalHandler()
-var whatUserSelected = handler.selectedRect()
+  //get selection
+  var selection = context.selection
+  var handler = context.document.eventHandlerManager().normalHandler()
+  var whatUserSelected = handler.selectedRect()
 
-//get size and shape
-var theOriginalShape = whatUserSelected.origin
-var theOriginalSize = whatUserSelected.size
+  //get size and shape
+  var theOriginalShape = whatUserSelected.origin
+  var theOriginalSize = whatUserSelected.size
 
-//new artboard size
-var newArtboard = MSArtboardGroup.new()
-var artboardFrame = newArtboard.frame()
+  //new artboard size
+  var newArtboard = MSArtboardGroup.new()
+  var artboardFrame = newArtboard.frame()
 
-//set that artboard size
-artboardFrame.setX(theOriginalShape.x)
-artboardFrame.setY(theOriginalShape.y)
-artboardFrame.setWidth(theOriginalSize.width)
-artboardFrame.setHeight(theOriginalSize.height)
+  //set that artboard size
+  artboardFrame.setX(theOriginalShape.x)
+  artboardFrame.setY(theOriginalShape.y)
+  artboardFrame.setWidth(theOriginalSize.width)
+  artboardFrame.setHeight(theOriginalSize.height)
 
-// name the artboard
-newArtboard.name = selection.firstObject().name()
+  // name the artboard
+  newArtboard.name = selection.firstObject().name()
 
-// move layers
-for (var i=0; i<[selection count]; i++) {
-  selection[i].setOrigin({x: 0, y: 0})
-  selection[i].parentGroup().removeLayer(selection[i])
-}
-newArtboard.addLayers(selection)
+  // move layers
+  for (var i=0; i<[selection count]; i++) {
+    selection[i].setOrigin({x: 0, y: 0})
+    selection[i].parentGroup().removeLayer(selection[i])
+  }
+  newArtboard.addLayers(selection)
 
-doc.currentPage().addLayers([newArtboard])
+  doc.currentPage().addLayers([newArtboard])
 };

--- a/SizeArtboard.sketchplugin/Contents/Sketch/script.cocoascript
+++ b/SizeArtboard.sketchplugin/Contents/Sketch/script.cocoascript
@@ -2,6 +2,7 @@ var onRun = function(context) {
   var doc = context.document
 
 //get selection
+var selection = context.selection
 var handler = context.document.eventHandlerManager().normalHandler()
 var whatUserSelected = handler.selectedRect()
 
@@ -18,6 +19,9 @@ artboardFrame.setX(theOriginalShape.x)
 artboardFrame.setY(theOriginalShape.y)
 artboardFrame.setWidth(theOriginalSize.width)
 artboardFrame.setHeight(theOriginalSize.height)
+
+// name the artboard
+newArtboard.name = selection.firstObject().name()
 
 doc.currentPage().addLayers([newArtboard])
 };

--- a/SizeArtboard.sketchplugin/Contents/Sketch/script.cocoascript
+++ b/SizeArtboard.sketchplugin/Contents/Sketch/script.cocoascript
@@ -23,5 +23,12 @@ artboardFrame.setHeight(theOriginalSize.height)
 // name the artboard
 newArtboard.name = selection.firstObject().name()
 
+// move layers
+for (var i=0; i<[selection count]; i++) {
+  selection[i].setOrigin({x: 0, y: 0})
+  selection[i].parentGroup().removeLayer(selection[i])
+}
+newArtboard.addLayers(selection)
+
 doc.currentPage().addLayers([newArtboard])
 };

--- a/SizeArtboard.sketchplugin/Contents/Sketch/script.cocoascript
+++ b/SizeArtboard.sketchplugin/Contents/Sketch/script.cocoascript
@@ -25,9 +25,13 @@ var onRun = function(context) {
 
   // move layers
   for (var i=0; i<[selection count]; i++) {
-    selection[i].setOrigin({x: 0, y: 0})
+    var frame = selection[i].frame()
+    var frameX = frame.x() - theOriginalShape.x
+    var frameY = frame.y() - theOriginalShape.y
+    selection[i].setOrigin({x: frameX, y: frameY})
     selection[i].parentGroup().removeLayer(selection[i])
   }
+  
   newArtboard.addLayers(selection)
 
   doc.currentPage().addLayers([newArtboard])


### PR DESCRIPTION
I found that the selected layers weren't moving into the newly-created artboard as expected, so my commit https://github.com/mazil/SizeArtboard/commit/0b54e9da77b9b4baa8e800641894edb66e722cf2 fixes this.

Perhaps a niche case, but I also wanted to bulk-rename the artboards as I went. 

Apologies for the indenting diff!